### PR TITLE
Fix tutorial standalone builds in Docker (closes #12)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.13.0)
 
 PROJECT(SemiDiscreteOT VERSION 1.0.0 LANGUAGES CXX C)
-ADD_COMPILE_DEFINITIONS(HX=HX HY=HY HZ=HZ)
 
 
 # Check Deal.II
@@ -33,6 +32,9 @@ ENDIF()
 
 # Find vtk
 FIND_PACKAGE(VTK QUIET)
+IF(VTK_FOUND AND DEFINED VTK_USE_FILE)
+    INCLUDE(${VTK_USE_FILE})
+ENDIF()
 
 # Add custom release target
 ADD_CUSTOM_TARGET(release
@@ -102,6 +104,17 @@ TARGET_COMPILE_DEFINITIONS(SemiDiscreteOT
         POWER_DIAGRAM_WITH_DEALII
         POWER_DIAGRAM_WITH_GEOGRAM
 )
+
+# Workaround: HZ (and HX, HY) is defined as a macro in Linux system headers
+# (e.g. <sys/param.h>), conflicting with VTK's vtkPointLocator.h member variables.
+# Redefining them to themselves neutralizes the macro while preserving the identifier.
+# PUBLIC ensures this propagates to consumers linking against SemiDiscreteOT.
+TARGET_COMPILE_DEFINITIONS(SemiDiscreteOT PUBLIC HX=HX HY=HY HZ=HZ)
+
+# Propagate VTK include directories to consumers
+IF(VTK_FOUND AND DEFINED VTK_INCLUDE_DIRS)
+    TARGET_INCLUDE_DIRECTORIES(SemiDiscreteOT PUBLIC ${VTK_INCLUDE_DIRS})
+ENDIF()
 
 # Create the executable
 ADD_EXECUTABLE(sot src/ComputeSot.cc)

--- a/cmake/SemiDiscreteOTConfig.cmake.in
+++ b/cmake/SemiDiscreteOTConfig.cmake.in
@@ -4,8 +4,9 @@ include(CMakeFindDependencyMacro)
 
 # Find dependencies
 find_dependency(deal.II 9.5.0 REQUIRED)
+find_dependency(VTK QUIET)
 
 # Import targets
 include("${CMAKE_CURRENT_LIST_DIR}/SemiDiscreteOTTargets.cmake")
 
-check_required_components(SemiDiscreteOT) 
+check_required_components(SemiDiscreteOT)

--- a/examples/tutorial_0/CMakeLists.txt
+++ b/examples/tutorial_0/CMakeLists.txt
@@ -16,8 +16,13 @@ PROJECT(Tutorial0 VERSION 1.0.0 LANGUAGES CXX C)
 SET(CMAKE_CXX_STANDARD 17)
 SET(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-SET(SemiDiscreteOT_DIR ../../build)
-FIND_PACKAGE(VTK REQUIRED)
+# Find SemiDiscreteOT (for standalone builds outside the main project)
+IF(NOT TARGET SemiDiscreteOT)
+    FIND_PACKAGE(SemiDiscreteOT REQUIRED)
+ENDIF()
+
+# Find VTK (optional: comes through deal.II or SemiDiscreteOT)
+FIND_PACKAGE(VTK QUIET)
 
 # Collect source files
 FILE(GLOB_RECURSE TUTORIAL_SOURCES "src/*.cc")
@@ -30,8 +35,12 @@ TARGET_INCLUDE_DIRECTORIES(tutorial_0 PRIVATE
     ${CMAKE_SOURCE_DIR}/include
 )
 
-# Link with RSOT and Deal.II
-TARGET_LINK_LIBRARIES(tutorial_0 SemiDiscreteOT)
+# Link with SemiDiscreteOT and Deal.II
+IF(TARGET SemiDiscreteOT::SemiDiscreteOT)
+    TARGET_LINK_LIBRARIES(tutorial_0 SemiDiscreteOT::SemiDiscreteOT)
+ELSE()
+    TARGET_LINK_LIBRARIES(tutorial_0 SemiDiscreteOT)
+ENDIF()
 DEAL_II_SETUP_TARGET(tutorial_0)
 
 # Set output directory

--- a/examples/tutorial_1/CMakeLists.txt
+++ b/examples/tutorial_1/CMakeLists.txt
@@ -16,8 +16,13 @@ PROJECT(Tutorial1 VERSION 1.0.0 LANGUAGES CXX C)
 SET(CMAKE_CXX_STANDARD 17)
 SET(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-SET(SemiDiscreteOT_DIR ../../build)
-FIND_PACKAGE(VTK REQUIRED)
+# Find SemiDiscreteOT (for standalone builds outside the main project)
+IF(NOT TARGET SemiDiscreteOT)
+    FIND_PACKAGE(SemiDiscreteOT REQUIRED)
+ENDIF()
+
+# Find VTK (optional: comes through deal.II or SemiDiscreteOT)
+FIND_PACKAGE(VTK QUIET)
 
 # Collect source files
 FILE(GLOB_RECURSE TUTORIAL_SOURCES "src/*.cc")
@@ -30,8 +35,12 @@ TARGET_INCLUDE_DIRECTORIES(tutorial_1 PRIVATE
     ${CMAKE_SOURCE_DIR}/include
 )
 
-# Link with RSOT and Deal.II
-TARGET_LINK_LIBRARIES(tutorial_1 SemiDiscreteOT)
+# Link with SemiDiscreteOT and Deal.II
+IF(TARGET SemiDiscreteOT::SemiDiscreteOT)
+    TARGET_LINK_LIBRARIES(tutorial_1 SemiDiscreteOT::SemiDiscreteOT)
+ELSE()
+    TARGET_LINK_LIBRARIES(tutorial_1 SemiDiscreteOT)
+ENDIF()
 DEAL_II_SETUP_TARGET(tutorial_1)
 
 # Set output directory

--- a/examples/tutorial_2/CMakeLists.txt
+++ b/examples/tutorial_2/CMakeLists.txt
@@ -9,15 +9,19 @@ FIND_PACKAGE(deal.II 9.5.0 REQUIRED)
 DEAL_II_INITIALIZE_CACHED_VARIABLES()
 
 # Set project name
-PROJECT(Tutorial1 VERSION 1.0.0 LANGUAGES CXX C)
+PROJECT(Tutorial2 VERSION 1.0.0 LANGUAGES CXX C)
 
 # Set C++ standard
 SET(CMAKE_CXX_STANDARD 17)
 SET(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-SET(SemiDiscreteOT_DIR ../../build)
-#FIND_PACKAGE(SemiDiscreteOT REQUIRED)
-#FIND_PACKAGE(VTK REQUIRED)
+# Find SemiDiscreteOT (for standalone builds outside the main project)
+IF(NOT TARGET SemiDiscreteOT)
+    FIND_PACKAGE(SemiDiscreteOT REQUIRED)
+ENDIF()
+
+# Find VTK (optional: comes through deal.II or SemiDiscreteOT)
+FIND_PACKAGE(VTK QUIET)
 
 # Collect source files
 FILE(GLOB_RECURSE TUTORIAL_SOURCES "src/*.cc")
@@ -30,14 +34,15 @@ TARGET_INCLUDE_DIRECTORIES(tutorial_2 PRIVATE
     ${CMAKE_SOURCE_DIR}/include
 )
 
-# Link with RSOT and Deal.II
-#TARGET_LINK_LIBRARIES(tutorial_2 SemiDiscreteOT::SemiDiscreteOT)
-TARGET_LINK_LIBRARIES(tutorial_2 SemiDiscreteOT)
+# Link with SemiDiscreteOT and Deal.II
+IF(TARGET SemiDiscreteOT::SemiDiscreteOT)
+    TARGET_LINK_LIBRARIES(tutorial_2 SemiDiscreteOT::SemiDiscreteOT)
+ELSE()
+    TARGET_LINK_LIBRARIES(tutorial_2 SemiDiscreteOT)
+ENDIF()
 DEAL_II_SETUP_TARGET(tutorial_2)
 
 # Set output directory
 SET_TARGET_PROPERTIES(tutorial_2 PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/run
 )
-
-message(STATUS "CMAKE_BUILD_TYPE = ${CMAKE_BUILD_TYPE}")

--- a/examples/tutorial_3/CMakeLists.txt
+++ b/examples/tutorial_3/CMakeLists.txt
@@ -9,11 +9,16 @@ FIND_PACKAGE(deal.II 9.5.0 REQUIRED)
 DEAL_II_INITIALIZE_CACHED_VARIABLES()
 
 # Set project name
-PROJECT(Tutorial1 VERSION 1.0.0 LANGUAGES CXX)
+PROJECT(Tutorial3 VERSION 1.0.0 LANGUAGES CXX)
 
 # Set C++ standard
 SET(CMAKE_CXX_STANDARD 17)
 SET(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Find SemiDiscreteOT (for standalone builds outside the main project)
+IF(NOT TARGET SemiDiscreteOT)
+    FIND_PACKAGE(SemiDiscreteOT REQUIRED)
+ENDIF()
 
 # Collect source files
 FILE(GLOB_RECURSE TUTORIAL_SOURCES "src/*.cc")
@@ -26,13 +31,15 @@ TARGET_INCLUDE_DIRECTORIES(tutorial_3 PRIVATE
     ${CMAKE_SOURCE_DIR}/include
 )
 
-# Link with RSOT and Deal.II
-TARGET_LINK_LIBRARIES(tutorial_3 SemiDiscreteOT)
+# Link with SemiDiscreteOT and Deal.II
+IF(TARGET SemiDiscreteOT::SemiDiscreteOT)
+    TARGET_LINK_LIBRARIES(tutorial_3 SemiDiscreteOT::SemiDiscreteOT)
+ELSE()
+    TARGET_LINK_LIBRARIES(tutorial_3 SemiDiscreteOT)
+ENDIF()
 DEAL_II_SETUP_TARGET(tutorial_3)
 
 # Set output directory
 SET_TARGET_PROPERTIES(tutorial_3 PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/run
 )
-
-message(STATUS "CMAKE_BUILD_TYPE = ${CMAKE_BUILD_TYPE}")

--- a/examples/tutorial_4/CMakeLists.txt
+++ b/examples/tutorial_4/CMakeLists.txt
@@ -15,8 +15,13 @@ PROJECT(Tutorial4 VERSION 1.0.0 LANGUAGES CXX C)
 SET(CMAKE_CXX_STANDARD 17)
 SET(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-SET(SemiDiscreteOT_DIR ../../build)
-FIND_PACKAGE(VTK REQUIRED)
+# Find SemiDiscreteOT (for standalone builds outside the main project)
+IF(NOT TARGET SemiDiscreteOT)
+    FIND_PACKAGE(SemiDiscreteOT REQUIRED)
+ENDIF()
+
+# Find VTK (optional: comes through deal.II or SemiDiscreteOT)
+FIND_PACKAGE(VTK QUIET)
 
 # Create executables
 ADD_EXECUTABLE(tutorial_4_gradient_descent src/main_gradient_descent.cc)
@@ -31,8 +36,13 @@ TARGET_INCLUDE_DIRECTORIES(tutorial_4_lloyd PRIVATE
 )
 
 # Link with SemiDiscreteOT and Deal.II
-TARGET_LINK_LIBRARIES(tutorial_4_gradient_descent SemiDiscreteOT)
-TARGET_LINK_LIBRARIES(tutorial_4_lloyd SemiDiscreteOT)
+IF(TARGET SemiDiscreteOT::SemiDiscreteOT)
+    TARGET_LINK_LIBRARIES(tutorial_4_gradient_descent SemiDiscreteOT::SemiDiscreteOT)
+    TARGET_LINK_LIBRARIES(tutorial_4_lloyd SemiDiscreteOT::SemiDiscreteOT)
+ELSE()
+    TARGET_LINK_LIBRARIES(tutorial_4_gradient_descent SemiDiscreteOT)
+    TARGET_LINK_LIBRARIES(tutorial_4_lloyd SemiDiscreteOT)
+ENDIF()
 DEAL_II_SETUP_TARGET(tutorial_4_gradient_descent)
 DEAL_II_SETUP_TARGET(tutorial_4_lloyd)
 

--- a/examples/tutorial_5/CMakeLists.txt
+++ b/examples/tutorial_5/CMakeLists.txt
@@ -9,11 +9,16 @@ FIND_PACKAGE(deal.II 9.5.0 REQUIRED)
 DEAL_II_INITIALIZE_CACHED_VARIABLES()
 
 # Set project name
-PROJECT(Tutorial1 VERSION 1.0.0 LANGUAGES CXX)
+PROJECT(Tutorial5 VERSION 1.0.0 LANGUAGES CXX)
 
 # Set C++ standard
 SET(CMAKE_CXX_STANDARD 17)
 SET(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Find SemiDiscreteOT (for standalone builds outside the main project)
+IF(NOT TARGET SemiDiscreteOT)
+    FIND_PACKAGE(SemiDiscreteOT REQUIRED)
+ENDIF()
 
 # Collect source files
 FILE(GLOB_RECURSE TUTORIAL_SOURCES "src/*.cc")
@@ -26,13 +31,15 @@ TARGET_INCLUDE_DIRECTORIES(tutorial_5 PRIVATE
     ${CMAKE_SOURCE_DIR}/include
 )
 
-# Link with RSOT and Deal.II
-TARGET_LINK_LIBRARIES(tutorial_5 SemiDiscreteOT)
+# Link with SemiDiscreteOT and Deal.II
+IF(TARGET SemiDiscreteOT::SemiDiscreteOT)
+    TARGET_LINK_LIBRARIES(tutorial_5 SemiDiscreteOT::SemiDiscreteOT)
+ELSE()
+    TARGET_LINK_LIBRARIES(tutorial_5 SemiDiscreteOT)
+ENDIF()
 DEAL_II_SETUP_TARGET(tutorial_5)
 
 # Set output directory
 SET_TARGET_PROPERTIES(tutorial_5 PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/run
 )
-
-message(STATUS "CMAKE_BUILD_TYPE = ${CMAKE_BUILD_TYPE}")


### PR DESCRIPTION
## Summary

Fixes #12 — tutorials failed to build standalone in the Docker image due to three compounding issues:

- **HZ macro conflict**: The `HX=HX HY=HY HZ=HZ` workaround was a global compile definition that didn't propagate to standalone tutorial builds. Changed to `TARGET_COMPILE_DEFINITIONS(SemiDiscreteOT PUBLIC ...)` so it's exported via the installed cmake target.
- **Library not found**: Tutorials used `SET(SemiDiscreteOT_DIR ../../build)` but never called `find_package(SemiDiscreteOT)`, so the installed library wasn't discovered. Added proper `find_package` with target detection for both standalone and in-tree builds.
- **VTK REQUIRED**: Tutorials 0, 1, 4 had `FIND_PACKAGE(VTK REQUIRED)` but VTK comes through deal.II's configuration. Changed to `QUIET`.

Additional fixes:
- Added VTK as a dependency in `SemiDiscreteOTConfig.cmake.in`
- Propagated VTK include directories and `VTK_USE_FILE` in root CMake
- Fixed incorrect project names in tutorials 2, 3, 5

## Test plan

- [x] Built Docker image with changes (`docker build --platform linux/amd64 -t semidiscreteot-test -f Dockerfile.library .`)
- [x] Verified all tutorials (0–5) build standalone inside the container